### PR TITLE
feat: ChatInputBar 컴포넌트 구현

### DIFF
--- a/src/components/chat/chatRoom/ChatInputBar.tsx
+++ b/src/components/chat/chatRoom/ChatInputBar.tsx
@@ -1,0 +1,74 @@
+import { PLACEHOLDERS } from '@/lib/constants/placeholders';
+import React, { useRef, useState } from 'react';
+import { IoMdArrowRoundUp } from 'react-icons/io';
+import { LuImagePlus } from 'react-icons/lu';
+
+interface ChatInputBarProps {
+  onSendMessage: (message: string) => void;
+}
+
+export default function ChatInputBar({ onSendMessage }: ChatInputBarProps) {
+  const [message, setMessage] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageUpload = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    console.log('선택된 이미지:', file);
+
+    e.target.value = '';
+  };
+
+  const handleSendMessage = () => {
+    if (!message.trim()) return;
+
+    onSendMessage(message);
+    setMessage('');
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center w-full max-w-[600px] bg-white border border-b-0 border-lineGrey px-5 py-3.5">
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        accept="image/*"
+        className="hidden"
+      />
+      <button
+        className="bg-[#EEEEEE] flex items-center justify-center rounded-full w-10 h-10 mr-3"
+        onClick={handleImageUpload}
+      >
+        <LuImagePlus size={30} color="#3b3b3b" />
+      </button>
+      <input
+        placeholder={PLACEHOLDERS.CHAT_INPUT}
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        onKeyPress={handleKeyPress}
+        className="w-full h-12 px-5 py-3 text-textBlack text-base font-medium outline-none shadow-inputShadow rounded-[1.25rem] border-[1px] border-lineGrey focus:border-[1px] focus:border-mainColor resize-none flex-1"
+      />
+      <button
+        className={`ml-3 flex h-10 w-10 items-center justify-center rounded-full ${
+          message.trim() ? 'bg-mainColor' : 'bg-lineGrey cursor-not-allowed'
+        }`}
+        onClick={handleSendMessage}
+        disabled={!message.trim()}
+      >
+        <IoMdArrowRoundUp size={30} color="white" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #9 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1️⃣ ChatInputBar 컴포넌트 구현
1. image-btn: 클릭 시 파일 선택할 수 있게 구현
2. input
3. send-btn: input창이 비어있는 경우 비활성화 

### 사용 예시
`<ChatInputBar onSendMessage={handleSendMessage} />`

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| ChatInputBar (input 비활성화) | ChatInputBar (input 활성화) |
|--|--|
| <img width="500" alt="스크린샷 2025-05-29 오전 2 15 45" src="https://github.com/user-attachments/assets/497cac87-69b1-400d-b949-7f0f476c9dba" /> | <img width="500" alt="스크린샷 2025-05-29 오전 2 14 26" src="https://github.com/user-attachments/assets/12017b26-ce3d-4bb2-a839-e4981c8c0191" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
