### PR TITLE
[Feat] ChatList, Item 컴포넌트 구현

### DIFF
--- a/src/app/(main)/chat/list/page.tsx
+++ b/src/app/(main)/chat/list/page.tsx
@@ -1,0 +1,10 @@
+import Header from '@/components/common/Header';
+import React from 'react';
+
+export default function ChatListPage() {
+  return (
+    <div>
+      <Header isChat={false} />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,3 +46,10 @@ body {
   min-height: 100dvh;
   margin: 0 auto;
 }
+
+.line-clamp-1 {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/src/assets/images/sample-square.svg
+++ b/src/assets/images/sample-square.svg
@@ -1,0 +1,3 @@
+<svg width="63" height="63" viewBox="0 0 63 63" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="63" height="63" rx="10" fill="#E4E4E4"/>
+</svg>

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -4,7 +4,7 @@ interface ChatListPropTypes {
   title: string;
   items: {
     id: number;
-    rastaurant_image: string;
+    restaurant_image: string;
     restaurant_name: string;
     menu_name: string;
     recent_message: string;

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -1,0 +1,29 @@
+import Item from '../ui/Item';
+
+interface ChatListPropTypes {
+  title: string;
+  items: {
+    id: number;
+    rastaurant_image: string;
+    restaurant_name: string;
+    menu_name: string;
+    recent_message: string;
+  }[];
+}
+export default function ChatList({ title, items }: ChatListPropTypes) {
+  return (
+    <div className="w-full">
+      <div className="py-[16px] px-[17px] text-lg font-bold text-textBlack bg-white">
+        {title}
+        {title == '상담중' && (
+          <span className="ml-1 text-mainColor">{items.length}</span>
+        )}
+      </div>
+      <div className="bg-white">
+        {items.map((item, idx) => (
+          <Item key={idx} data={item} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -8,6 +8,7 @@ export type LayoutProps = {
   center?: boolean;
   gap?: string;
   scrollToTop?: boolean;
+  className?: string;
 };
 
 export const Layout = ({
@@ -16,6 +17,7 @@ export const Layout = ({
   center = false,
   gap = 'gap-0',
   scrollToTop = false,
+  className,
 }: LayoutProps) => {
   useEffect(() => {
     if (scrollToTop) window.scrollTo(0, 0);
@@ -26,5 +28,7 @@ export const Layout = ({
     ? `flex flex-col justify-center items-center ${gap}`
     : '';
 
-  return <div className={`${baseClass} ${centerClass}`}>{children}</div>;
+  return (
+    <div className={`${baseClass} ${centerClass}${className}`}>{children}</div>
+  );
 };

--- a/src/components/ui/Item.tsx
+++ b/src/components/ui/Item.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 interface ItemPropTypes {
   data: {
     id: number;
-    rastaurant_image: string;
+    restaurant_image: string;
     restaurant_name: string;
     menu_name: string;
     recent_message: string;
@@ -16,7 +16,7 @@ interface ItemPropTypes {
 
 export default function Item({ data }: ItemPropTypes) {
   const router = useRouter();
-  const { id, rastaurant_image, restaurant_name, menu_name, recent_message } =
+  const { id, restaurant_image, restaurant_name, menu_name, recent_message } =
     data;
 
   const handleClick = () => {
@@ -31,7 +31,7 @@ export default function Item({ data }: ItemPropTypes) {
     >
       <div className="w-20 h-20 relative flex-shrink-0">
         <Image
-          src={rastaurant_image}
+          src={restaurant_image}
           alt="가게 사진"
           fill
           className="object-cover rounded-md"

--- a/src/components/ui/Item.tsx
+++ b/src/components/ui/Item.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+interface ItemPropTypes {
+  data: {
+    id: number;
+    rastaurant_image: string;
+    restaurant_name: string;
+    menu_name: string;
+    recent_message: string;
+  };
+}
+
+export default function Item({ data }: ItemPropTypes) {
+  const router = useRouter();
+  const { id, rastaurant_image, restaurant_name, menu_name, recent_message } =
+    data;
+
+  const handleClick = () => {
+    console.log('Clicked item with id:', id);
+    router.push(`/chat/${id}`);
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className="w-full px-4 py-5 bg-White border-b border-LineGrey flex flex-row gap-3.5 overflow-hidden cursor-pointer last:border-b-0"
+    >
+      <div className="w-20 h-20 relative flex-shrink-0">
+        <Image
+          src={rastaurant_image}
+          alt="가게 사진"
+          fill
+          className="object-cover rounded-md"
+        />
+      </div>
+      <div className="flex flex-col gap-1 justify-center">
+        <div className="text-TextBlack text-lg font-bold ">
+          {restaurant_name}
+        </div>
+        <div className=" text-TextBlack text-sm font-normal">{menu_name}</div>
+        <div className="text-textLightGrey text-sm font-normal line-clamp-1 ">
+          {recent_message}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #13 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1️⃣ Item 컴포넌트 구현
`id`, `restaurant_image`, `restaurant_name`, `menu_name`, `recent_message` 를 prop으로 넘겨줘야 함
### 사용 예시
```
<div className="bg-white">
  {items.map((item, idx) => (
    <Item key={idx} data={item} />
  ))}
</div>
```

### 2️⃣ ChatList 컴포넌트 구현
title prop을 통해 "상담중" 또는 "상담종료" 중 하나를 전달받아, 해당 제목에 맞는 채팅 목록을 렌더링
### 사용 예시
```
<div className="mt-5">
  <ChatList title="상담중" items={ongoingChats} />
</div>
<div className="mt-5">
  <ChatList title="상담종료" items={endedChats} />
</div>
```


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| Item 컴포넌트 | ChatList 컴포넌트(`title = "상담중"`) |  ChatList 컴포넌트(`title = "상담종료"`) |
|--|--|--|
| <img width="500" alt="스크린샷 2025-06-03 오전 2 03 05" src="https://github.com/user-attachments/assets/b02ea16a-f4a7-4422-b9cc-c16720fe95a6" /> | <img width="500" alt="스크린샷 2025-06-03 오전 2 03 13" src="https://github.com/user-attachments/assets/e3221550-56c5-47e7-adfd-14edd2c621e1" /> | <img width="500" alt="스크린샷 2025-06-03 오전 2 03 22" src="https://github.com/user-attachments/assets/c0be156c-9faa-404f-9faa-fabf1cf5fb35" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
CSS에서 `:last-of-type` 를 사용하면 마지막 아이템의 border를 제거 가능.
tailwind CSS에서는 :last-of-type 대신 `last:` 접두사를 사용 ➡️ `last:border-b-0`
