### PR TITLE
[Feat] ChatList 페이지 구현

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -82,7 +82,7 @@ export default function LoginPage() {
           </button>
         </div>
       </div>
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 w-[22.4375rem]">
         <Button disabled={!isValid} onClick={handleLogin}>
           로그인
         </Button>

--- a/src/app/(main)/chat/list/page.tsx
+++ b/src/app/(main)/chat/list/page.tsx
@@ -1,10 +1,69 @@
+'use client';
+
+import ChatList from '@/components/chat/ChatList';
 import Header from '@/components/common/Header';
+import { Layout } from '@/components/common/Layout';
 import React from 'react';
+import sampleImage from '@/assets/images/sample-square.svg';
+import Button from '@/components/ui/Button';
 
 export default function ChatListPage() {
+  const ongoingChats: {
+    id: number;
+    restaurant_image: string;
+    restaurant_name: string;
+    menu_name: string;
+    recent_message: string;
+  }[] = [
+    {
+      id: 1,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      recent_message:
+        '안녕하세요 TALKTITUDE입니다. 무엇을 도와드릴까요? 안녕하세요 TALKTITUDE입니다. 무엇을 도와드릴까요?',
+    },
+    {
+      id: 2,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      recent_message: '안녕하세요 TALKTITUDE입니다. 무엇을 도와드릴까요?',
+    },
+  ];
+
+  const endedChats: {
+    id: number;
+    restaurant_image: string;
+    restaurant_name: string;
+    menu_name: string;
+    recent_message: string;
+  }[] = [
+    {
+      id: 3,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      recent_message: '안녕하세요 TALKTITUDE입니다. 무엇을 도와드릴까요?',
+    },
+  ];
+
   return (
-    <div>
+    <div className="bg-bgLightBlue">
       <Header isChat={false} />
+      <Layout padding="pt-14 pb-40 border-x border-lineGrey">
+        <div className="mt-5">
+          <ChatList title="상담중" items={ongoingChats} />
+        </div>
+        <div className="mt-5">
+          <ChatList title="상담종료" items={endedChats} />
+        </div>
+      </Layout>
+      <div className="fixed w-full max-w-[600px] bottom-0 bg-bgLightBlue p-4 z-10 border-x border-lineGrey">
+        <Button onClick={() => console.log('상담 시작하기')}>
+          상담 시작하기
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/chat/ChatList.tsx
+++ b/src/components/chat/ChatList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Item from '../ui/Item';
 
 interface ChatListPropTypes {
@@ -10,6 +12,7 @@ interface ChatListPropTypes {
     recent_message: string;
   }[];
 }
+
 export default function ChatList({ title, items }: ChatListPropTypes) {
   return (
     <div className="w-full">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,7 +13,7 @@ export default function Header({
   isChat = false,
 }: ChatHeaderPropTypes) {
   return (
-    <div className="w-full max-w-[600px] fixed">
+    <div className="w-full max-w-[600px] fixed z-10">
       <div className=" h-14 bg-mainColor flex items-center justify-start px-[22px]">
         <Image
           src={WhiteLogo}

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -8,7 +8,6 @@ export type LayoutProps = {
   center?: boolean;
   gap?: string;
   scrollToTop?: boolean;
-  className?: string;
 };
 
 export const Layout = ({
@@ -17,7 +16,6 @@ export const Layout = ({
   center = false,
   gap = 'gap-0',
   scrollToTop = false,
-  className,
 }: LayoutProps) => {
   useEffect(() => {
     if (scrollToTop) window.scrollTo(0, 0);
@@ -28,7 +26,5 @@ export const Layout = ({
     ? `flex flex-col justify-center items-center ${gap}`
     : '';
 
-  return (
-    <div className={`${baseClass} ${centerClass}${className}`}>{children}</div>
-  );
+  return <div className={`${baseClass} ${centerClass}`}>{children}</div>;
 };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -16,9 +16,9 @@ export default function Button({
       disabled={disabled}
       onClick={onClick}
       className={`
-        flex w-[22.4375rem] h-13 py-3.5
+        flex w-full h-13 py-3.5
         justify-center items-center 
-        rounded-[1.25rem] text-lg font-bold
+        rounded-[1rem] text-lg font-bold
         ${disabled ? 'bg-textLightGrey cursor-not-allowed' : 'bg-mainColor cursor-pointer'}
         text-white
       `}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -18,7 +18,7 @@ export default function Button({
       className={`
         flex w-full h-13 py-3.5
         justify-center items-center 
-        rounded-[1rem] text-lg font-bold
+        rounded-[1.25rem] text-lg font-bold
         ${disabled ? 'bg-textLightGrey cursor-not-allowed' : 'bg-mainColor cursor-pointer'}
         text-white
       `}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #15 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1️⃣ 목데이터 추가 (ongoingChats, endedChats로 분리하여 관리)
```
 {
  id: 1,
  restaurant_image: sampleImage,
  restaurant_name: '구공분식 강남점',
  menu_name: '야끼만두 외 4개 13,218원',
  recent_message:
    '안녕하세요 TALKTITUDE입니다. 무엇을 도와드릴까요? 안녕하세요 TALKTITUDE입니다. 무엇을 도와드릴까요?',
},
```

### 2️⃣ Header, Layout, ChatList 컴포넌트 import
```
<Header isChat={false} />
<Layout padding="pt-14 pb-40 border-x border-lineGrey">
  <div className="mt-5">
    <ChatList title="상담중" items={ongoingChats} />
  </div>
  <div className="mt-5">
    <ChatList title="상담종료" items={endedChats} />
  </div>
</Layout>
```

### 3️⃣ Button 컴포넌트 import
1. "상담 시작하기" 버튼을 fixed 속성으로 화면 하단에 고정하여 항상 표시되도록 구현
2. 아직 주문 유형을 선택하는 페이지가 없어 console.log로 클릭 이벤트 설정

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| ChatList 페이지(스크롤 X) | ChatList 페이지(스크롤 O) | 
|--|--|
|<img width="602" alt="스크린샷 2025-06-03 오전 2 55 06" src="https://github.com/user-attachments/assets/8f163152-665c-4343-ac71-9a1bb5499671" /> |<img width="602" alt="스크린샷 2025-06-03 오전 3 00 44" src="https://github.com/user-attachments/assets/118c73ac-ec31-40b6-8711-192aa248e2f3" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->

fixed 속성을 사용할 때 w-full만 설정하면 부모 컨테이너의 너비를 따르지 않고 전체 화면을 기준으로 너비가 설정됨
➡️ max-width를 먼저 지정한 후 w-full을 적용하면, 부모 요소의 너비 범위 내에서 꽉 차도록 설정 가능.