### PR TITLE
[Feat] ChatNew 페이지 구현

### DIFF
--- a/src/app/(main)/chat/list/page.tsx
+++ b/src/app/(main)/chat/list/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import ChatList from '@/components/chat/ChatList';
+import ChatList from '@/components/chat/chatList/ChatList';
 import Header from '@/components/common/Header';
 import { Layout } from '@/components/common/Layout';
 import React from 'react';

--- a/src/app/(main)/chat/new/page.tsx
+++ b/src/app/(main)/chat/new/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import Header from '@/components/common/Header';
+import { Layout } from '@/components/common/Layout';
+import sampleImage from '@/assets/images/sample-square.svg';
+import ChatOrderList from '@/components/chat/chatNew/ChatOrderList';
+import Link from 'next/link';
+
+export default function ChatNewPage() {
+  const orderList: {
+    id: number;
+    restaurant_image: string;
+    restaurant_name: string;
+    menu_name: string;
+    order_date: string;
+  }[] = [
+    {
+      id: 1,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      order_date: '2025년 05월 16일 오후 08:56',
+    },
+    {
+      id: 2,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      order_date: '2025년 05월 16일 오후 08:56',
+    },
+    {
+      id: 3,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      order_date: '2025년 05월 16일 오후 08:56',
+    },
+    {
+      id: 4,
+      restaurant_image: sampleImage,
+      restaurant_name: '구공분식 강남점',
+      menu_name: '야끼만두 외 4개 13,218원',
+      order_date: '2025년 05월 16일 오후 08:56',
+    },
+  ];
+
+  return (
+    <div className="bg-bgLightBlue">
+      <Header isChat={false} />
+      <Layout padding="pt-14 pb-20 border-x border-lineGrey">
+        <div className="mt-5">
+          <ChatOrderList items={orderList} />
+        </div>
+        <div className="mt-20 text-center underline text-textLightGrey text-sm font-bold">
+          <Link href="/chat/:id">주문 말고 다른 문의가 있어요</Link>
+        </div>
+      </Layout>
+    </div>
+  );
+}

--- a/src/components/chat/chatList/ChatList.tsx
+++ b/src/components/chat/chatList/ChatList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Item from '../ui/Item';
+import Item from '../../ui/Item';
 
 interface ChatListPropTypes {
   title: string;

--- a/src/components/chat/chatNew/ChatOrderList.tsx
+++ b/src/components/chat/chatNew/ChatOrderList.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import Item from '../../ui/Item';
+
+interface ChatOrderListPropTypes {
+  items: {
+    id: number;
+    restaurant_image: string;
+    restaurant_name: string;
+    menu_name: string;
+    order_date: string;
+  }[];
+}
+
+function ChatOrderList({ items }: ChatOrderListPropTypes) {
+  return (
+    <div className="w-full">
+      <div className="py-[16px] px-[17px] text-lg font-bold text-mainColor bg-white">
+        문의하고 싶은 주문을 선택해주세요.
+      </div>
+      <div className="bg-white">
+        {items.map((item, idx) => (
+          <Item key={idx} data={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ChatOrderList;

--- a/src/components/ui/Item.tsx
+++ b/src/components/ui/Item.tsx
@@ -10,14 +10,21 @@ interface ItemPropTypes {
     restaurant_image: string;
     restaurant_name: string;
     menu_name: string;
-    recent_message: string;
+    recent_message?: string;
+    order_date?: string;
   };
 }
 
 export default function Item({ data }: ItemPropTypes) {
   const router = useRouter();
-  const { id, restaurant_image, restaurant_name, menu_name, recent_message } =
-    data;
+  const {
+    id,
+    restaurant_image,
+    restaurant_name,
+    menu_name,
+    recent_message,
+    order_date,
+  } = data;
 
   const handleClick = () => {
     console.log('Clicked item with id:', id);
@@ -42,8 +49,8 @@ export default function Item({ data }: ItemPropTypes) {
           {restaurant_name}
         </div>
         <div className=" text-TextBlack text-sm font-normal">{menu_name}</div>
-        <div className="text-textLightGrey text-sm font-normal line-clamp-1 ">
-          {recent_message}
+        <div className="text-textLightGrey text-sm font-normal line-clamp-1">
+          {recent_message || order_date}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #17 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1️⃣ Item 컴포넌트에 order_date prop 추가
```
recent_message?: string;
order_date?: string;
```
`recent_message`와 `order_date`를 선택적 prop으로 설정
`{recent_message || order_date}`: 둘 중 하나가 있을 경우 해당 값을 표시

### 2️⃣ ChatOrderList 컴포넌트 구현
```
items: {
  id: number;
  restaurant_image: string;
  restaurant_name: string;
  menu_name: string;
  order_date: string;
}[];
```
items 라는 prop이 필요한 컴포넌트 

### 3️⃣ ChatNew 페이지 구현
1. Header, Layout, ChatOrderList 컴포넌트 import
2. Link 설정 (주문말고 다른 문의가 있어요)
`<Link href="/chat/:id">주문 말고 다른 문의가 있어요</Link>` ➡️ `/chat/:id` (채팅방 페이지)로 이동하게 설정



## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| ChatOrderList 컴포넌트 | Link 설정 | ChatNew 페이지 |
|--|--|--|
| <img width="598" alt="스크린샷 2025-06-03 오전 3 33 41" src="https://github.com/user-attachments/assets/3dffe7e5-c378-463c-9dca-558ed581d3de" /> |<img width="598" alt="스크린샷 2025-06-03 오전 3 33 50" src="https://github.com/user-attachments/assets/aa8dc731-a5f3-4233-9144-4a8696b8d6b8" /> | <img width="602" alt="스크린샷 2025-06-03 오전 3 33 30" src="https://github.com/user-attachments/assets/03b4583c-429d-4969-b427-802c1dfcf638" /> |

## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
